### PR TITLE
update pom.xml for 12-bit support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,9 +116,9 @@
 		</dependency>
 		
 		<dependency>
-    		<groupId>org.bytedeco.javacpp-presets</groupId>
-    		<artifactId>ffmpeg-platform</artifactId>
-    		<version>4.0.1-1.4.2</version>
+			<groupId>org.bytedeco.javacpp-presets</groupId>
+			<artifactId>ffmpeg-platform</artifactId>
+			<version>4.1-1.4.4</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
I updated the pom.xml for 12-bit x265 encoding support. It is included in version 1.4.4 of JavaCPP presets for FFMPEG.