### PR TITLE
Bump pom-scijava to 31.1.0 and jhdf5 to 19.04.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>26.0.0</version>
+		<version>31.1.0</version>
 		<relativePath />
 	</parent>
 
@@ -101,6 +101,7 @@
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
 
 		<ffmpeg-platform.version>4.1-1.4.4</ffmpeg-platform.version>
+		<cisd.jhdf5.version>19.04.0</cisd.jhdf5.version>
 	</properties>
 
 	<repositories>
@@ -119,6 +120,7 @@
 		<dependency>
 			<groupId>cisd</groupId>
 			<artifactId>jhdf5</artifactId>
+			<version>${cisd.jhdf5.version}</version>
 		</dependency>
 		
 		<dependency>


### PR DESCRIPTION
This updates the jhdf5 library to version 19.04.0 per scijava/pom-scijava#181

