### PR TITLE
Register plugin in File > Import...

### DIFF
--- a/src/main/resources/plugins.config
+++ b/src/main/resources/plugins.config
@@ -6,4 +6,4 @@
 # Name: Read Janelia HDF5
 # Author: fosterl@janelia.hhmi.org
 # Version: 1.0.0
-Plugins, "Janelia H265 Reader", org.janelia.it.fiji.plugins.h5j.H5j_Reader
+File>Import, "Janelia H265 Reader", org.janelia.it.fiji.plugins.h5j.H5j_Reader


### PR DESCRIPTION
Rather than root Pugins > menu, which is rather an unexpected place for a reader, and only contributes to menu clutter